### PR TITLE
Refined filter to only include *_test.js files in the test directory.

### DIFF
--- a/tasks/init/commonjs/root/Gruntfile.js
+++ b/tasks/init/commonjs/root/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       },
     },
     nodeunit: {
-      files: ['test/**/*.js']
+      files: ['test/**/*_test.js']
     },
     jshint: {
       options: {

--- a/tasks/init/gruntfile/root/Gruntfile.js
+++ b/tasks/init/gruntfile/root/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = function(grunt) {
       files: ['{%= test_dir %}/**/*.html']
     },{% } else { %}
     {%= test_task %}: {
-      files: ['{%= test_dir %}/**/*.js']
+      files: ['{%= test_dir %}/**/*_test.js']
     },{% } %}
     watch: {
       gruntfile: {

--- a/tasks/init/node/root/Gruntfile.js
+++ b/tasks/init/node/root/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
   // Project configuration.
   grunt.initConfig({
     nodeunit: {
-      files: ['test/**/*.js'],
+      files: ['test/**/*_test.js'],
     },
     jshint: {
       options: {


### PR DESCRIPTION
Every time I use grunt I always encounter issues with grunt picking up every .js file in my test folder and trying to run them as nodeunit files.

This patch simply reduces the filter to match only files named _test.js to avoid this confusing others in the future.

I noticed you have already corrected one this in one of the templates, I have changed the others to match.
