### PR TITLE
detect and skip processing of common binary files.

### DIFF
--- a/tasks/init.js
+++ b/tasks/init.js
@@ -373,6 +373,11 @@ module.exports = function(grunt) {
             }
             srcpath = helpers.getFile(srcpath);
           }
+
+          if (helpers.isBinary(srcpath)) {
+            o.noProcess = true;
+          }
+
           // Copy!
           init.copy(srcpath, destpath, o);
         });

--- a/tasks/lib/helpers.js
+++ b/tasks/lib/helpers.js
@@ -148,5 +148,16 @@ exports.init = function(grunt) {
     return result;
   };
 
+  exports.isBinary = function(filepath) {
+    var binaryExtensions = [
+      'dds', 'eot', 'gif', 'ico', 'jar', 'jpeg', 'jpg',
+      'pdf', 'png', 'swf', 'tga', 'ttf', 'zip'
+    ];
+
+    var ext = filepath.replace(/.*[\.\/]/, '').toLowerCase();
+
+    return grunt.util._.contains(binaryExtensions, ext);
+  };
+
   return exports;
 };

--- a/test/helpers_test.js
+++ b/test/helpers_test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var grunt = require('grunt');
+var helpers = require('../tasks/lib/helpers').init(grunt);
+
+exports['helpers'] = {
+  'isBinary': function(test) {
+    test.expect(3);
+    test.equal(helpers.isBinary('path/file.jpg'), true, 'It should return true.');
+    test.equal(helpers.isBinary('path/file.txt'), false, 'It should return false.');
+    test.equal(helpers.isBinary('path/file.styl'), false, 'It should return false.');
+    test.done();
+  }
+};


### PR DESCRIPTION
this helps prevent the processing of common binary files by default. this is a safe list and only for convenience.
