### PR TITLE
 fix init.prompt error on not-build-in property

### DIFF
--- a/tasks/lib/prompt.js
+++ b/tasks/lib/prompt.js
@@ -138,7 +138,7 @@ exports.init = function(grunt, helpers) {
   // Commonly-used prompt options with meaningful default values.
   exports.prompt = function(name, altDefault) {
     // Clone the option so the original options object doesn't get modified.
-    var option = grunt.util._.clone(exports.prompts[name]);
+    var option = grunt.util._.clone(exports.prompts[name] || {});
     option.name = name;
 
     var defaults = helpers.readDefaults('defaults.json');


### PR DESCRIPTION
This request is to fix: https://github.com/gruntjs/grunt-init/issues/44
