### PR TITLE
writes `scripts` property in package.json

### DIFF
--- a/tasks/init.js
+++ b/tasks/init.js
@@ -414,8 +414,10 @@ module.exports = function(grunt) {
         if (props.main) { pkg.main = props.main; }
         if (props.bin) { pkg.bin = props.bin; }
         if (props.node_version) { pkg.engines = {node: props.node_version}; }
+        if (props.scripts) { pkg.scripts = props.scripts; }
         if (props.npm_test) {
-          pkg.scripts = {test: props.npm_test};
+          pkg.scripts = pkg.scripts || {};
+          pkg.scripts.test = props.npm_test; // `npm_test` property takes precedence over the user-defined `scripts.test` property
           if (props.npm_test.split(' ')[0] === 'grunt') {
             if (!props.devDependencies) { props.devDependencies = {}; }
             if (!props.devDependencies.grunt) {


### PR DESCRIPTION
The writePackageJSON method did not allow to generate a `package.json` that had a `scripts` entry.

This is what this PR solves.

Until now, if there were a `npm_test` prop in the configuration, it was output as a `scripts.test` property in the file. This behaviour has been maintained. However, if the `scripts` property contains a conflicting `test` property, the one provided with `npm_test` takes precedence over it, for backward-compatibility.
## 

IMHO, the `npm_test` prop should be eventually deprecated. Some time later maybe... :wink: 
