### PR TITLE
Repository default falls back to github user from git config.

### DIFF
--- a/tasks/lib/git.js
+++ b/tasks/lib/git.js
@@ -42,5 +42,19 @@ exports.init = function(grunt) {
     return url;
   };
 
+  // Get the given key from the git config, if it exists.
+  exports.config = function(key, done) {
+    grunt.util.spawn({
+      cmd: 'git',
+      args: ['config', '--get', key]
+    }, function(err, result) {
+      if (err) {
+        done(true, 'none');
+        return;
+      }
+      done(null, String(result));
+    });
+  };
+
   return exports;
 };


### PR DESCRIPTION
Previously, `repository` key default guessed `process.env.USER{NAME}` as the user's GitHub handle, without checking the user's git config for a `github.user` key, even though that was checked later in the `sanitize` function, when populating the `git_user` key. This commit does the check earlier for a smarter default in case no git remote URL is found from `git.origin`.
