### PR TITLE
Set `grunt.util.linefeed` for `copyAndProcess()`

### DIFF
--- a/bin/grunt-init
+++ b/bin/grunt-init
@@ -20,7 +20,18 @@ var pkg = require(asset('package.json'));
 
 // Grunt.
 var grunt = require('grunt');
+var git = require(asset('tasks/lib/git')).init(grunt);
 var helpers = require(asset('tasks/lib/helpers')).init(grunt);
+
+git.config('core.autocrlf', function (err, autocrlf) {
+  if (err) {
+    autocrlf = 'false';
+  }
+
+  if (autocrlf === 'false') {
+    grunt.util.linefeed = '\n';
+  }
+});
 
 // Hook into grunt.task.init to load the built-in init task.
 hooker.hook(grunt.task, 'init', function() {


### PR DESCRIPTION
`copyAndProcess()` converts line endings on Windows as mentioned in
issue #42. This should be configurable.

`grunt.template.process` uses `grunt.util.normalizelf()`, and this
function looks `grunt.util.linefeed` for line endings normalization;
therefore setting this property fixes a problem on Windows.

I think Git's [`core.autocrlf`](http://git-scm.com/book/en/Customizing-Git-Git-Configuration#Formatting-and-Whitespace) configuration helps to determine
whether `grunt-init` should normalize LF or not. If this configuration
is `input` or `true`, there is no problem with LF normalization.

`grunt-init` should set `grunt.util.linefeed` to `\n` when
`core.autocrlf` is `false` for preventing LF normalization.
