### PR TITLE
Add license prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,14 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "prompt": "~0.1.12",
-    "semver": "~1.0.14",
-    "hooker": "~0.2.3",
+    "async": "~0.2.10",
     "colors": "~0.6.0-1",
     "grunt": "~0.4.0",
+    "hooker": "~0.2.3",
     "lodash": "~2.4.1",
-    "async": "~0.2.10"
+    "prompt": "~0.1.12",
+    "semver": "~1.0.14",
+    "spdx": "^0.4.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.8.0",

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
 
   // External libs.
   var semver = require('semver');
+  var spdx = require('spdx');
   var _ = require('lodash');
 
   // Internal libs.
@@ -125,6 +126,7 @@ module.exports = function(grunt) {
       keywords: {
         message: 'Project keywords (separated by space)',
         sanitize: function(value, data, done) { 
+          /*jshint laxbreak:true*/
           done(null, value 
                         ? value.replace(/^\s+|\s+$/g, '')
                                .split(/\s+/)
@@ -203,6 +205,14 @@ module.exports = function(grunt) {
           done(null, git.githubUrl(data.repository, 'issues') || 'none');
         },
         warning: 'Should be a public URL.'
+      },
+      license: {
+        message: 'License',
+        default: 'MIT',
+        validator: spdx.valid,
+        warning: 'Must be a valid SPDX License Expression (spdx.org). Built-in ' +
+          'licenses are: ' + helpers.availableLicenses().join(' ') + ', but you may ' +
+          'specify any valid license expression.'
       },
       licenses: {
         message: 'Licenses',
@@ -412,7 +422,7 @@ module.exports = function(grunt) {
       writePackageJSON: function(filename, props, callback) {
         var pkg = {};
         // Basic values.
-        ['name', 'title', 'description', 'version', 'homepage'].forEach(function(prop) {
+        ['name', 'title', 'description', 'version', 'homepage', 'license'].forEach(function(prop) {
           if (prop in props) { pkg[prop] = props[prop]; }
         });
         // Author.
@@ -487,6 +497,7 @@ module.exports = function(grunt) {
           grunt.util.spawn({cmd: 'npm', args: ['install'],
                             opts: {cwd: init.destpath, stdio: 'inherit'}},
               function(error, result, code) {
+                /*jshint unused:vars*/
                 if (done) {
                   done();
                 }

--- a/tasks/lib/prompt.js
+++ b/tasks/lib/prompt.js
@@ -167,7 +167,7 @@ exports.init = function(grunt, helpers) {
   // Sanitize function for Yes/No values that converts value to boolean
   exports.sanitizeYesNo = function(value, data, done) {
     done(null, value !== 'y/N' && /^\s*y[es\s]*/i.test(value));
-  }
+  };
   
   return exports;
 };


### PR DESCRIPTION
Hello,

I have added `license` built-in prompt that conforms to [npm’s package.json requirements](https://docs.npmjs.com/files/package.json#license) and fixed several `jshint` complaints.
