### PR TITLE
added 'reporterOutput:''' to avoid path error

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,8 @@
 /*
- * grunt-init
- * https://gruntjs.com/
+ * grunt-bms-docker
+ * https://github.com/r.b.hicks/grunt-arena
  *
- * Copyright (c) 2016 "Cowboy" Ben Alman, contributors
+ * Copyright (c) 2018 
  * Licensed under the MIT license.
  */
 
@@ -15,12 +15,37 @@ module.exports = function(grunt) {
     jshint: {
       all: [
         'Gruntfile.js',
-        'bin/grunt-init',
-        'tasks/**/*.js',
-        'init/*.js',
+        'tasks/*.js',
+        '<%= nodeunit.tests %>'
       ],
       options: {
-        jshintrc: '.jshintrc'
+        jshintrc: '.jshintrc',
+        reporterOutput: ''
+      }
+    },
+
+    // Before generating any new files, remove any previously-created files.
+    clean: {
+      tests: ['tmp']
+    },
+
+    // Configuration to be run (and then tested).
+    bms_docker: {
+      default_options: {
+        options: {
+        },
+        files: {
+          'tmp/default_options': ['test/fixtures/testing', 'test/fixtures/123']
+        }
+      },
+      custom_options: {
+        options: {
+          separator: ': ',
+          punctuation: ' !!!'
+        },
+        files: {
+          'tmp/custom_options': ['test/fixtures/testing', 'test/fixtures/123']
+        }
       }
     },
 
@@ -28,6 +53,7 @@ module.exports = function(grunt) {
     nodeunit: {
       tests: ['test/*_test.js']
     }
+
   });
 
   // Actually load this plugin's task(s).
@@ -35,10 +61,12 @@ module.exports = function(grunt) {
 
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
-  // Whenever the "test" task is run, run some tests.
-  grunt.registerTask('test', 'nodeunit');
+  // Whenever the "test" task is run, first clean the "tmp" dir, then run this
+  // plugin's task(s), then test the result.
+  grunt.registerTask('test', ['clean', 'bms_docker', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);


### PR DESCRIPTION
Hello,

I ran into to following when running grunt after setting up a new template:

`Running "jshint:all" (jshint) task`
`Warning: The "path" argument must be of type string Use --force to continue.`

Adding:

`reporterOutput: ''`

to jshint.options corrected the problem.

Cheers,

-r